### PR TITLE
tests/lib/hardware: Create HardwareBase class

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def linear_rook_cluster(kubernetes):
         rook_cluster.install_rook()
         yield rook_cluster
 
+
 @pytest.fixture(scope="module")
 def rook_cluster():
     with Hardware() as hardware:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,16 @@
 import pytest
 import threading
 
-from tests.lib.hardware import Hardware
+from tests import config
 from tests.lib.kubernetes import VanillaKubernetes
 from tests.lib.rook import RookCluster
+
+
+if config.CLOUD_PROVIDER == 'OPENSTACK':
+    from tests.lib.hardware import Hardware as Hardware
+else:
+    raise Exception("Cloud provider '{}' not yet supported by "
+                    "smoke_rook".format(config.CLOUD_PROVIDER))
 
 
 @pytest.fixture(scope="module")

--- a/tests/lib/kubernetes.py
+++ b/tests/lib/kubernetes.py
@@ -481,7 +481,6 @@ class VanillaKubernetes():
             # TODO(jhesketh): Provide some more useful feedback and/or checking
             raise Exception("One or more hosts failed")
 
-
         r = self.hardware.execute_ansible_play(d.setup_master_play())
 
         if r.host_failed or r.host_unreachable:

--- a/tests/test_node_addition.py
+++ b/tests/test_node_addition.py
@@ -23,4 +23,3 @@ def test_debug_scope_order(rook_cluster):
 
     with os.fdopen(os.dup(2), "r") as stdin:
         return stdin.readline()
-


### PR DESCRIPTION
Use a base class to abstract the methods a hardware class needs to
have. The former hardware class has now only libcloud OpenStack
specific code inside.
Also prefix some methods with _ to mark it as private methods.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>