### PR TITLE
tests/lib/hardware/base: Move base unrelated vars

### DIFF
--- a/tests/lib/hardware/base.py
+++ b/tests/lib/hardware/base.py
@@ -47,9 +47,6 @@ class HardwareBase(ABC):
         self.hardware_uuid = str(uuid.uuid4())[:8]
         self.conn = self.get_connection()
 
-        self._image_cache = {}
-        self._size_cache = {}
-
         # NOTE(jhesketh): The working_dir is never cleaned up. This is somewhat
         # deliberate to keep the private key if it is needed for debugging.
         self.working_dir = tempfile.mkdtemp(

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -231,6 +231,9 @@ class Hardware(HardwareBase):
         self._ex_security_group = self._create_security_group()
         self._ex_network_cache = {}
 
+        self._image_cache = {}
+        self._size_cache = {}
+
         print(self.pubkey)
         print(self.private_key)
 


### PR DESCRIPTION
_image_cache and _size_cache are unrelated to base but an
implementation detail of the libcloud implementation. So move the
variables there.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>