### PR TITLE
Add some basic type hints for mypy

### DIFF
--- a/tests/lib/ansible_helper.py
+++ b/tests/lib/ansible_helper.py
@@ -28,6 +28,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from typing import Dict
 import urllib.request
 import yaml
 
@@ -41,6 +42,8 @@ import ansible.plugins.loader
 import ansible.executor.task_queue_manager
 from ansible.plugins.callback.default import CallbackModule
 import ansible.constants as C
+
+from tests.lib.hardware.base import NodeBase
 
 
 class ResultCallback(CallbackModule):
@@ -76,7 +79,7 @@ class ResultCallback(CallbackModule):
 
 
 class AnsibleRunner(object):
-    def __init__(self, nodes, working_dir=None):
+    def __init__(self, nodes: Dict[str, NodeBase], working_dir=None):
         # since the API is constructed for CLI it expects certain options to
         # always be set in the context object
         ansible_context.CLIARGS = ImmutableDict(

--- a/tests/lib/hardware/base.py
+++ b/tests/lib/hardware/base.py
@@ -27,6 +27,7 @@
 from abc import ABC, abstractmethod
 import os
 import tempfile
+from typing import Dict, Any
 import uuid
 
 import paramiko.rsakey
@@ -79,7 +80,7 @@ class HardwareBase(ABC):
         pass
 
     @abstractmethod
-    def boot_nodes(self, masters=1, workers=2, offset=0):
+    def boot_nodes(self, masters: int = 1, workers: int = 2, offset: int = 0):
         pass
 
     @abstractmethod
@@ -100,17 +101,18 @@ class NodeBase(ABC):
     """
     Base class for nodes
     """
-    def __init__(self, name):
+    def __init__(self, name: str, private_key: str):
         self.name = name
+        self.private_key = private_key
 
     @abstractmethod
-    def get_ssh_ip(self):
+    def get_ssh_ip(self) -> str:
         """
         Get the IP address that can be used to ssh into the node
         """
         pass
 
-    def ansible_inventory_vars(self):
+    def ansible_inventory_vars(self) -> Dict[str, Any]:
         vars = {
             'ansible_host': self.get_ssh_ip(),
             # FIXME(jhesketh): Set username depending on OS

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -48,7 +48,7 @@ else:
 class Node(NodeBase):
     def __init__(self, conn, name, pubkey=None, private_key=None,
                  tags=[]):
-        super().__init__(name)
+        super().__init__(name, private_key)
         self.conn = conn
         self.libcloud_node = None
 
@@ -56,7 +56,6 @@ class Node(NodeBase):
         self.volumes = []
         self.tags = tags
         self.pubkey = pubkey
-        self.private_key = private_key
 
         self._ssh_client = None
 


### PR DESCRIPTION
That's useful for static code checking.
Also move private_key to the base class. That's an error that mypy
detected.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>