### PR TITLE
tests/lib/kubernetes: Fix get_ssh_ip() call

### DIFF
--- a/tests/lib/kubernetes.py
+++ b/tests/lib/kubernetes.py
@@ -521,7 +521,7 @@ class VanillaKubernetes():
                 "annotate node %s "
                 "flannel.alpha.coreos.com/public-ip-overwrite=%s "
                 "--overwrite" % (
-                    node.name.replace("_", "-"), node._get_ssh_ip()
+                    node.name.replace("_", "-"), node.get_ssh_ip()
                 )
             )
         self.kubectl_apply(


### PR DESCRIPTION
Commit bdb377028916ad1 removed the private marker for get_ssh_ip(). So
fix it when using the method.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>