### PR TITLE
Use python logging module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import pytest
 import threading
 
@@ -25,6 +26,9 @@ if config.CLOUD_PROVIDER == 'OPENSTACK':
 else:
     raise Exception("Cloud provider '{}' not yet supported by "
                     "smoke_rook".format(config.CLOUD_PROVIDER))
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
@@ -68,7 +72,7 @@ def rook_cluster():
     with Hardware() as hardware:
         with VanillaKubernetes(hardware) as kubernetes:
             with RookCluster(kubernetes) as rook_cluster:
-                print("Starting rook build in a thread")
+                logger.info("Starting rook build in a thread")
                 build_thread = threading.Thread(target=rook_cluster.build_rook)
                 build_thread.start()
 
@@ -77,7 +81,7 @@ def rook_cluster():
                 hardware.prepare_nodes()
                 kubernetes.install_kubernetes()
 
-                print("Re-joining rook build thread")
+                logger.info("Re-joining rook build thread")
                 build_thread.join()
                 # NOTE(jhesketh): The upload is very slow.. may want to
                 #                 consider how to do this in a thread too but

--- a/tests/lib/ansible_helper.py
+++ b/tests/lib/ansible_helper.py
@@ -22,6 +22,7 @@
 # take the form of cloud-init or similar bringing the target node to an
 # expected state.
 
+import logging
 import os
 import shutil
 import tarfile
@@ -42,6 +43,9 @@ from ansible.plugins.callback.default import CallbackModule
 import ansible.constants as C
 
 from tests.lib.hardware.node_base import NodeBase
+
+
+logger = logging.getLogger(__name__)
 
 
 class ResultCallback(CallbackModule):
@@ -198,7 +202,7 @@ class AnsibleRunner(object):
         return results_callback
 
     def download_mitogen(self, working_dir):
-        print("Downloading and unpacking mitogen")
+        logger.info("Downloading and unpacking mitogen")
         tar_url = "https://networkgenomics.com/try/mitogen-0.2.9.tar.gz"
         stream = urllib.request.urlopen(tar_url)
         tar_file = tarfile.open(fileobj=stream, mode="r|gz")

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -23,6 +23,7 @@
 # expected state.
 
 from abc import ABC, abstractmethod
+import logging
 import os
 import tempfile
 from typing import Dict, Optional
@@ -35,14 +36,14 @@ from tests.lib.hardware.node_base import NodeBase
 from tests import config
 
 
+logger = logging.getLogger(__name__)
+
+
 class HardwareBase(ABC):
     """
     Base Hardware class
     """
     def __init__(self):
-        # Boot nodes
-        print("boot nodes")
-        print(self)
         self.nodes: Dict[str, NodeBase] = {}
         self._hardware_uuid: str = str(uuid.uuid4())[:8]
         self.conn = self.get_connection()
@@ -84,11 +85,11 @@ class HardwareBase(ABC):
 
     @abstractmethod
     def boot_nodes(self, masters: int = 1, workers: int = 2, offset: int = 0):
-        pass
+        logger.info("boot nodes")
 
     @abstractmethod
     def prepare_nodes(self):
-        pass
+        logger.info("prepare nodes")
 
     def execute_ansible_play(self, play_source):
         if not self._ansible_runner or \

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -22,6 +22,7 @@
 # take the form of cloud-init or similar bringing the target node to an
 # expected state.
 
+import logging
 import subprocess
 import threading
 import time
@@ -36,6 +37,7 @@ from tests.lib.hardware.hardware_base import HardwareBase
 from tests.lib.hardware.node_base import NodeBase
 from tests import config
 
+logger = logging.getLogger(__name__)
 libcloud.security.VERIFY_SSL_CERT = config.VERIFY_SSL_CERT
 
 if config.DISTRO == 'openSUSE_k8s':
@@ -80,17 +82,14 @@ class Node(NodeBase):
             **kwargs
         )
 
-        print("Created node: ")
-        print(self)
-        print(self.libcloud_node)
+        logger.info(f"Created node: {self.libcloud_node}")
 
     def create_and_attach_floating_ip(self):
         # TODO(jhesketh): Move cloud-specific configuration elsewhere
         floating_ip = self.conn.ex_create_floating_ip(
             config.OS_EXTERNAL_NETWORK)
 
-        print("Created floating IP: ")
-        print(floating_ip)
+        logger.info(f"Created floating IP: {floating_ip}")
         self.floating_ips.append(floating_ip)
 
         # Wait until the node is running before assigning IP
@@ -101,8 +100,7 @@ class Node(NodeBase):
     def create_and_attach_volume(self, size=10):
         vol_name = "%s-vol-%d" % (self.name, len(self.volumes))
         volume = self.conn.create_volume(size=size, name=vol_name)
-        print("Created volume: ")
-        print(volume)
+        logger.info(f"Created volume: {volume}")
 
         # Wait for volume to be ready before attaching
         self.wait_until_volume_state(volume.uuid)
@@ -214,8 +212,8 @@ class Hardware(HardwareBase):
         self._image_cache = {}
         self._size_cache = {}
 
-        print(self.pubkey)
-        print(self.private_key)
+        logger.info(f"public key {self.pubkey}")
+        logger.info(f"private key {self.private_key}")
 
     def generate_keys(self):
         super().generate_keys()
@@ -374,8 +372,7 @@ class Hardware(HardwareBase):
 
     def destroy(self):
         # Remove nodes
-        print("destroy nodes")
-        print(self)
+        logger.info("destroy nodes")
 
         threads = []
         for node in self.nodes.values():

--- a/tests/lib/kubernetes.py
+++ b/tests/lib/kubernetes.py
@@ -19,6 +19,7 @@
 # would require SLE and can raise an exception if that isn't provided.
 
 from abc import ABC, abstractmethod
+import logging
 import os
 import stat
 import subprocess
@@ -26,6 +27,9 @@ import wget
 
 import kubernetes
 from tests import config
+
+
+logger = logging.getLogger(__name__)
 
 
 class Deploy(ABC):
@@ -441,13 +445,10 @@ class VanillaKubernetes():
         self.hardware = hardware
         self.kubeconfig = None
         self.v1 = None
-        print("kube init")
-        print(self)
-        print(self.hardware)
+        logger.info(f"kube init on hardware {self.hardware}")
 
     def destroy(self, skip=True):
-        print("kube destroy")
-        print(self)
+        logger.info(f"kube destroy on hardware {self.hardware}")
         if skip:
             # We can skip in most cases since the nodes themselves will be
             # destroyed instead.
@@ -559,11 +560,9 @@ class VanillaKubernetes():
                 capture_output=True
             )
         except subprocess.CalledProcessError as e:
-            print("Command `%s` failed" % command)
-            print("STDOUT:")
-            print(e.stdout)
-            print("STDERR:")
-            print(e.stderr)
+            logger.exception(f"Command `{command}` failed")
+            logger.error(f"STDOUT: {e.stdout}")
+            logger.error(f"STDERR: {e.stderr}")
             raise
         return out
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ skipsdist = True
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 commands =
-  py.test --capture=sys -s {posargs}
+  py.test --log-cli-level=INFO --capture=sys -s {posargs}
 passenv =
   CLOUD_PROVIDER
   CLUSTER_PREFIX


### PR DESCRIPTION
Instead of doing prints, use logging to log messages. That way, we can
have different log levels and more control over the output in general.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>